### PR TITLE
Update to fs.unlink to remove deprecation warning on node > 7.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,9 @@ WebpackAutoCleanBuildPlugin.prototype = {
 				var file = path.resolve(options.output.path, fileName);
 				var prevFile = self.previousFiles[key];
 				if (prevFile && prevFile != file) {
-					fs.unlink(prevFile);
+					fs.unlink(prevFile, (error) => {
+						console.log(error)
+					});
 				}
 				self.previousFiles[key] = file;
 			}


### PR DESCRIPTION
Minor update to remove dep warnings for later versions of node.

https://nodejs.org/api/fs.html#fs_fs_unlink_path_callback